### PR TITLE
Part12 - Camera clamp only works towards the right

### DIFF
--- a/Assets/StarterAssets/ThirdPersonController/Scripts/ThirdPersonController.cs
+++ b/Assets/StarterAssets/ThirdPersonController/Scripts/ThirdPersonController.cs
@@ -214,12 +214,13 @@ namespace StarterAssets
             {
                 _cinemachineTargetYaw = minY;
             }
-            else if (_cinemachineTargetPitch > maxY)
+            else if (_cinemachineTargetYaw > maxY)
             {
-                _cinemachineTargetPitch = maxY;
+                _cinemachineTargetYaw = maxY;
             }
             // clamp our rotations so our values are limited 360 degrees
-            //_cinemachineTargetYaw = ClampAngle(_cinemachineTargetYaw, float.MinValue, float.MaxValue);
+	    // Alternatively, this will work
+            //_cinemachineTargetYaw = ClampAngle(_cinemachineTargetYaw, -HorizontalClamp, HorizontalClamp);
             _cinemachineTargetPitch = ClampAngle(_cinemachineTargetPitch, BottomClamp, TopClamp);
 
             // Cinemachine will follow this target


### PR DESCRIPTION
I believe there's a bug by using the targetPitch in the second portion of the statement, you can only turn left and be clamped but on the right side you're unclamped (because we edit the pitch not the yaw)

For these clips, I made a public variable that just shows the value of the ClampedYaw after clamping (and the pitch) in one of them to showcase how that's being clamped (incorrectly)


https://github.com/user-attachments/assets/2f7847ea-15df-4a98-b525-186f4bfe5074

If we clamp both, we get a smoother result


https://github.com/user-attachments/assets/5c4be72b-f5e7-4530-9007-ae5b67b02809

I also tested with the clamp angle, and I think it wasn't working possibly because of the values being passed in, looking at the pitch one, it goes from `-30` to `70` , by default, so I just made it go from `-90` to `90` and it seems to work just fine.

```cs
_cinemachineTargetYaw = ClampAngle(_cinemachineTargetYaw, -HorizontalClamp, HorizontalClamp);
```

And a clip with this clamping


https://github.com/user-attachments/assets/0e93346f-9d37-43cd-8880-9b9666501fb9

